### PR TITLE
[Done] Extract rasters, compute md5 sums and size

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ History
 - Added -m parameter (metadata_path) to cli, and --uuid to the download command. This
   enables mapping repo slugs to uuids.
 
+- Extract rasters referenced in sqlite and files changed in commit (changeset).
+
 
 0.1.0 (2021-11-11)
 ------------------

--- a/threedi_model_migration/cli.py
+++ b/threedi_model_migration/cli.py
@@ -180,7 +180,9 @@ def plan(ctx, indent):
     for schematisation in repository_to_schematisations(repository):
         revisions = schematisation.revisions
         rev_rng = f"{revisions[-1].revision_nr}-{revisions[0].revision_nr}"
-        print(f"{schematisation.concat_name}: {rev_rng}")
+        print(
+            f"{schematisation.concat_name}: {rev_rng}, {schematisation.total_size_mb} MB"
+        )
 
     with (inspection_path / f"{repository.slug}.plan.json").open("w") as f:
         json.dump(

--- a/threedi_model_migration/cli.py
+++ b/threedi_model_migration/cli.py
@@ -166,8 +166,14 @@ def inspect(ctx, indent, last_update, quiet):
     default=4,
     help="The indentation in case of JSON output",
 )
+@click.option(
+    "-q/-nq",
+    "--quiet/--not-quiet",
+    type=bool,
+    default=False,
+)
 @click.pass_context
-def plan(ctx, indent):
+def plan(ctx, indent, quiet):
     """Plans schematisation migration for given inspect result"""
     repository_slug = ctx.obj["repository"].slug
     inspection_path = ctx.obj["inspection_path"]
@@ -177,16 +183,22 @@ def plan(ctx, indent):
 
     assert repository.slug == repository_slug
 
-    for schematisation in repository_to_schematisations(repository):
-        revisions = schematisation.revisions
-        rev_rng = f"{revisions[-1].revision_nr}-{revisions[0].revision_nr}"
+    result = repository_to_schematisations(repository)
+    if not quiet:
+        print(f"Schematisation count: {result['count']}")
+
+        for schematisation in result["schematisations"]:
+            revisions = schematisation.revisions
+            rev_rng = f"{revisions[-1].revision_nr}-{revisions[0].revision_nr}"
+            print(f"{schematisation.concat_name}: {rev_rng}")
+
         print(
-            f"{schematisation.concat_name}: {rev_rng}, {schematisation.total_size_mb} MB"
+            f"File count: {result['file_count']}, Estimated size: {result['file_size_mb']} MB"
         )
 
     with (inspection_path / f"{repository.slug}.plan.json").open("w") as f:
         json.dump(
-            schematisation,
+            result,
             f,
             indent=indent,
             default=custom_json_serializer,

--- a/threedi_model_migration/conversion.py
+++ b/threedi_model_migration/conversion.py
@@ -1,3 +1,4 @@
+from .file import File
 from .repository import RepoSettings
 from .repository import Repository
 from .repository import RepoSqlite
@@ -73,10 +74,15 @@ def repository_to_schematisations(repository: Repository) -> List[Schematisation
                     last_update=revision.last_update,
                     commit_msg=revision.commit_msg,
                     commit_user=revision.commit_user,
+                    sqlite=File(sqlite.sqlite_path),
+                    rasters=settings.rasters,
                 )
             )
 
         # update previous_rev
         previous_rev = {uid: target for (uid, target) in zip(unique_ids, targets)}
+
+    # match the sqlite & rasters to the ones in the revision's changeset
+    pass
 
     return result

--- a/threedi_model_migration/conversion.py
+++ b/threedi_model_migration/conversion.py
@@ -21,12 +21,12 @@ def repository_to_schematisations(repository: Repository) -> List[Schematisation
 
     Supplied RepoSettings should belong to only 1 repository.
     """
-    # the result is a list of schematisations
-    result = []
+    # schemas is a list of schematisations
+    schemas = []
 
     # keep track only of the unique (sqlite_path,settings_id) combinations of the
     # previously processed (newer)
-    previous_rev = {}  # unique_id -> index into result
+    previous_rev = {}  # unique_id -> index into schemas
     for revision in sorted(repository.revisions, key=lambda x: -x.revision_nr):
         combinations = [
             (sqlite, settings)
@@ -65,12 +65,12 @@ def repository_to_schematisations(repository: Repository) -> List[Schematisation
                     settings_name=settings.settings_name,
                     revisions=[],
                 )
-                result.append(schematisation)
-                targets[i] = len(result) - 1
+                schemas.append(schematisation)
+                targets[i] = len(schemas) - 1
 
         # append the revision for each
         for (sqlite, settings), target in zip(combinations, targets):
-            result[target].revisions.append(
+            schemas[target].revisions.append(
                 SchemaRevision(
                     sqlite_path=sqlite.sqlite_path,
                     settings_name=settings.settings_name,
@@ -92,7 +92,14 @@ def repository_to_schematisations(repository: Repository) -> List[Schematisation
         # update previous_rev
         previous_rev = {uid: target for (uid, target) in zip(unique_ids, targets)}
 
-    for schematisation in result:
-        schematisation.summarize_files()
+    files = set()
+    for schematisation in schemas:
+        files |= schematisation.get_files()
 
-    return result
+    return {
+        "count": len(schemas),
+        "file_count": len(files),
+        "file_size_mb": int(sum(x.size for x in files) / (1024 ** 2)),
+        "repository_slug": repository.slug,
+        "schematisations": schemas,
+    }

--- a/threedi_model_migration/conversion.py
+++ b/threedi_model_migration/conversion.py
@@ -92,4 +92,7 @@ def repository_to_schematisations(repository: Repository) -> List[Schematisation
         # update previous_rev
         previous_rev = {uid: target for (uid, target) in zip(unique_ids, targets)}
 
+    for schematisation in result:
+        schematisation.summarize_files()
+
     return result

--- a/threedi_model_migration/file.py
+++ b/threedi_model_migration/file.py
@@ -61,4 +61,7 @@ class File:
 
 @dataclasses.dataclass
 class Raster(File):
+    path: Path
+    size: Optional[int] = None  # in bytes
+    md5: Optional[str] = None
     raster_type: RasterOptions = None

--- a/threedi_model_migration/file.py
+++ b/threedi_model_migration/file.py
@@ -10,6 +10,8 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+SQLITE_COMPRESSION_RATIO = 7
+
 
 class RasterOptions(Enum):
     dem_file = "dem_file"
@@ -62,6 +64,7 @@ class File:
 
     def compute_md5(self, base_path: Path):
         self.md5, self.size = compute_md5(base_path / self.path)
+        self.size = int(self.size / SQLITE_COMPRESSION_RATIO)
 
     def __hash__(self):
         return int(self.md5, 16)

--- a/threedi_model_migration/file.py
+++ b/threedi_model_migration/file.py
@@ -64,10 +64,8 @@ class File:
 
 @dataclasses.dataclass
 class Raster(File):
+    # Note: redefine fields so that __annotations__ is filled (used in json_utils.py)
     path: Path
     size: Optional[int] = None  # in bytes
     md5: Optional[str] = None
     raster_type: RasterOptions = None
-
-    def __hash__(self):
-        return int(self.md5, 16)

--- a/threedi_model_migration/file.py
+++ b/threedi_model_migration/file.py
@@ -5,11 +5,15 @@ from typing import Optional
 
 import dataclasses
 import hashlib
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 class RasterOptions(Enum):
-    # dem_file = "dem_file"
-    dem_raw_file = "dem_raw_file"
+    dem_file = "dem_file"
+    # dem_raw_file = "dem_raw_file"
     equilibrium_infiltration_rate_file = "equilibrium_infiltration_rate_file"
     frict_coef_file = "frict_coef_file"
     initial_groundwater_level_file = "initial_groundwater_level_file"
@@ -39,6 +43,7 @@ def _iter_chunks(fileobj: BinaryIO, chunk_size: int = 16777216):
 
 def compute_md5(path: Path, chunk_size: int = 16777216):
     """Returns md5 and file size"""
+    logger.debug(f"Computing hash of file {path}...")
     with path.open("rb") as fileobj:
         hasher = hashlib.md5()
         for chunk in _iter_chunks(fileobj, chunk_size=chunk_size):

--- a/threedi_model_migration/file.py
+++ b/threedi_model_migration/file.py
@@ -1,0 +1,64 @@
+from enum import Enum
+from pathlib import Path
+from typing import BinaryIO
+from typing import Optional
+
+import dataclasses
+import hashlib
+
+
+class RasterOptions(Enum):
+    # dem_file = "dem_file"
+    dem_raw_file = "dem_raw_file"
+    equilibrium_infiltration_rate_file = "equilibrium_infiltration_rate_file"
+    frict_coef_file = "frict_coef_file"
+    initial_groundwater_level_file = "initial_groundwater_level_file"
+    initial_waterlevel_file = "initial_waterlevel_file"
+    groundwater_hydro_connectivity_file = "groundwater_hydro_connectivity_file"
+    groundwater_impervious_layer_level_file = "groundwater_impervious_layer_level_file"
+    infiltration_decay_period_file = "infiltration_decay_period_file"
+    initial_infiltration_rate_file = "initial_infiltration_rate_file"
+    leakage_file = "leakage_file"
+    phreatic_storage_capacity_file = "phreatic_storage_capacity_file"
+    hydraulic_conductivity_file = "hydraulic_conductivity_file"
+    porosity_file = "porosity_file"
+    infiltration_rate_file = "infiltration_rate_file"
+    max_infiltration_capacity_file = "max_infiltration_capacity_file"
+    interception_file = "interception_file"
+
+
+def _iter_chunks(fileobj: BinaryIO, chunk_size: int = 16777216):
+    """Yield chunks from a file stream"""
+    assert chunk_size > 0
+    while True:
+        data = fileobj.read(chunk_size)
+        if len(data) == 0:
+            break
+        yield data
+
+
+def compute_md5(path: Path, chunk_size: int = 16777216):
+    """Returns md5 and file size"""
+    with path.open("rb") as fileobj:
+        hasher = hashlib.md5()
+        for chunk in _iter_chunks(fileobj, chunk_size=chunk_size):
+            hasher.update(chunk)
+        md5 = hasher.hexdigest()
+        file_size = fileobj.tell()
+
+    return md5, file_size
+
+
+@dataclasses.dataclass
+class File:
+    path: Path
+    size: Optional[int] = None  # in bytes
+    md5: Optional[str] = None
+
+    def compute_md5(self, base_path: Path):
+        self.md5, self.size = compute_md5(base_path / self.path)
+
+
+@dataclasses.dataclass
+class Raster(File):
+    raster_type: RasterOptions = None

--- a/threedi_model_migration/file.py
+++ b/threedi_model_migration/file.py
@@ -63,9 +63,14 @@ class File:
 
 
 @dataclasses.dataclass
-class Raster(File):
-    # Note: redefine fields so that __annotations__ is filled (used in json_utils.py)
+class Raster:
     path: Path
     size: Optional[int] = None  # in bytes
     md5: Optional[str] = None
     raster_type: RasterOptions = None
+
+    def compute_md5(self, base_path: Path):
+        self.md5, self.size = compute_md5(base_path / self.path)
+
+    def __hash__(self):
+        return int(self.md5, 16)

--- a/threedi_model_migration/file.py
+++ b/threedi_model_migration/file.py
@@ -58,6 +58,9 @@ class File:
     def compute_md5(self, base_path: Path):
         self.md5, self.size = compute_md5(base_path / self.path)
 
+    def __hash__(self):
+        return int(self.md5, 16)
+
 
 @dataclasses.dataclass
 class Raster(File):
@@ -65,3 +68,6 @@ class Raster(File):
     size: Optional[int] = None  # in bytes
     md5: Optional[str] = None
     raster_type: RasterOptions = None
+
+    def __hash__(self):
+        return int(self.md5, 16)

--- a/threedi_model_migration/hg.py
+++ b/threedi_model_migration/hg.py
@@ -92,3 +92,11 @@ def parse_log_entry(row):
 def log(repo_path):
     output = get_output(f'hg log -T "{LOG_TEMPLATE}"', cwd=repo_path, log=False)
     return [parse_log_entry(row) for row in output.strip().split("\n")]
+
+
+def files(repo_path, revision_hash):
+    """List all files in the repo"""
+    output = get_output(
+        f'hg files --rev {revision_hash} -X ".hgignore"', cwd=repo_path, log=False
+    )
+    return [x.lstrip(".hglf/") for x in output.strip().split("\n")]

--- a/threedi_model_migration/hg.py
+++ b/threedi_model_migration/hg.py
@@ -80,7 +80,8 @@ LOG_TEMPLATE = "{rev},{node},{desc|urlescape},{user|urlescape},{date|isodate},{f
 
 def filter_files(paths):
     for path in paths:
-        path = path.lstrip(".hglf/")
+        if path.startswith(".hglf/"):
+            path = path[6:]
         _, ext = os.path.splitext(path)
         if ext.lower() in (".tif", ".tiff", ".geotif", ".geotiff", ".sqlite"):
             yield Path(path)

--- a/threedi_model_migration/hg.py
+++ b/threedi_model_migration/hg.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from pathlib import Path
 from urllib.parse import unquote
 
 import logging
@@ -73,17 +74,18 @@ def convert_to_date(date: str) -> datetime:
     return datetime.fromisoformat(fixed_date)
 
 
-LOG_TEMPLATE = "{rev},{node},{desc|urlescape},{user|urlescape},{date|isodate}\n"
+LOG_TEMPLATE = "{rev},{node},{desc|urlescape},{user|urlescape},{date|isodate},{files % '{file|urlescape}|'}\n"
 
 
 def parse_log_entry(row):
-    rev, node, desc, user, date = row.split(",")
+    rev, node, desc, user, date, files = row.split(",")
     return {
         "revision_nr": int(rev),
         "revision_hash": node,
         "commit_msg": unquote(desc),
         "commit_user": unquote(user),
         "last_update": convert_to_date(date),
+        "changes": [Path(unquote(f.lstrip(".hglf/"))) for f in files.split("|")[:-1]],
     }
 
 

--- a/threedi_model_migration/json_utils.py
+++ b/threedi_model_migration/json_utils.py
@@ -1,3 +1,4 @@
+from .file import File
 from .repository import RepoRevision
 from .repository import RepoSettings
 from .repository import Repository
@@ -35,6 +36,7 @@ DATACLASS_TYPE_LOOKUP = {
         RepoSettings,
         Schematisation,
         SchemaRevision,
+        File,
     )
 }
 

--- a/threedi_model_migration/json_utils.py
+++ b/threedi_model_migration/json_utils.py
@@ -20,7 +20,9 @@ def custom_json_serializer(o):
     elif dataclasses.is_dataclass(o):
         result = OrderedDict(type=o.__class__.__name__)
         for field in dataclasses.fields(o):
-            result[field.name] = getattr(o, field.name)
+            value = getattr(o, field.name)
+            if value is not None:
+                result[field.name] = getattr(o, field.name)
         return result
 
 

--- a/threedi_model_migration/json_utils.py
+++ b/threedi_model_migration/json_utils.py
@@ -1,4 +1,5 @@
 from .file import File
+from .file import Raster
 from .repository import RepoRevision
 from .repository import RepoSettings
 from .repository import Repository
@@ -37,6 +38,7 @@ DATACLASS_TYPE_LOOKUP = {
         Schematisation,
         SchemaRevision,
         File,
+        Raster,
     )
 }
 
@@ -57,4 +59,8 @@ def custom_json_object_hook(dct):
         elif dtype is pathlib.Path:
             value = pathlib.Path(value)
         kwargs[name] = value
-    return cls(**kwargs)
+
+    try:
+        return cls(**kwargs)
+    except TypeError as e:
+        raise TypeError(f"Could not deserialize object {dct}: {e}")

--- a/threedi_model_migration/json_utils.py
+++ b/threedi_model_migration/json_utils.py
@@ -22,9 +22,7 @@ def custom_json_serializer(o):
     elif dataclasses.is_dataclass(o):
         result = OrderedDict(type=o.__class__.__name__)
         for field in dataclasses.fields(o):
-            value = getattr(o, field.name)
-            if value is not None:
-                result[field.name] = getattr(o, field.name)
+            result[field.name] = getattr(o, field.name)
         return result
 
 
@@ -60,7 +58,4 @@ def custom_json_object_hook(dct):
             value = pathlib.Path(value)
         kwargs[name] = value
 
-    try:
-        return cls(**kwargs)
-    except TypeError as e:
-        raise TypeError(f"Could not deserialize object {dct}: {e}")
+    return cls(**kwargs)

--- a/threedi_model_migration/repository.py
+++ b/threedi_model_migration/repository.py
@@ -197,8 +197,8 @@ class Repository:
                         break
                 revisions.append(revision)
 
-            # patch the 'changes' if filtering on last_update so that all files are
-            # present in the repository
+            # patch the 'changes' of the oldest commit when filtering on last_update
+            # so that all files are present in the Repository
             if last_update is not None and len(revisions) > 0:
                 revisions[-1].changes = [
                     File(x) for x in hg.files(self.path, revisions[-1].revision_hash)

--- a/threedi_model_migration/schematisation.py
+++ b/threedi_model_migration/schematisation.py
@@ -10,6 +10,9 @@ from typing import Optional
 __all__ = ["Schematisation", "SchemaRevision"]
 
 
+SQLITE_COMPRESSION_RATIO = 7
+
+
 @dataclass
 class SchemaRevision:
     sqlite_path: Path  # relative to repository dir
@@ -37,7 +40,7 @@ class Schematisation:
     settings_id: int
     settings_name: str  # the newest of its revisions
     file_count: Optional[int] = None
-    total_size: Optional[int] = None
+    total_size_mb: Optional[int] = None
     revisions: Optional[List[SchemaRevision]] = None
 
     @property
@@ -45,14 +48,16 @@ class Schematisation:
         return f"{self.slug}-{self.sqlite_name}-{self.settings_name}"
 
     def summarize_files(self):
-        unique_files = set()
+        unique_sqlites = set()
+        unique_rasters = set()
         for revision in self.revisions:
-            unique_files.add(revision.sqlite)
-            unique_files |= set(revision.rasters)
-        unique_files = list(unique_files)
+            unique_sqlites.add(revision.sqlite)
+            unique_rasters |= set(revision.rasters)
 
-        self.file_count = len(unique_files)
-        self.total_size = sum(x.size for x in unique_files)
+        self.file_count = len(unique_sqlites) + len(unique_rasters)
+        size_sqlites = sum(x.size for x in unique_sqlites) / SQLITE_COMPRESSION_RATIO
+        size_rasters = sum(x.size for x in unique_rasters)
+        self.total_size_mb = int((size_sqlites + size_rasters) / (1024 ** 2))
 
     def __repr__(self):
         return f"Schematisation({self.slug}, sqlite_name={self.sqlite_name}, settings_name={self.settings_name})"

--- a/threedi_model_migration/schematisation.py
+++ b/threedi_model_migration/schematisation.py
@@ -36,11 +36,23 @@ class Schematisation:
     sqlite_name: str  # the newest of its revisions
     settings_id: int
     settings_name: str  # the newest of its revisions
+    file_count: Optional[int] = None
+    total_size: Optional[int] = None
     revisions: Optional[List[SchemaRevision]] = None
 
     @property
     def concat_name(self):
         return f"{self.slug}-{self.sqlite_name}-{self.settings_name}"
+
+    def summarize_files(self):
+        unique_files = set()
+        for revision in self.revisions:
+            unique_files.add(revision.sqlite)
+            unique_files |= set(revision.rasters)
+        unique_files = list(unique_files)
+
+        self.file_count = len(unique_files)
+        self.total_size = sum(x.size for x in unique_files)
 
     def __repr__(self):
         return f"Schematisation({self.slug}, sqlite_name={self.sqlite_name}, settings_name={self.settings_name})"

--- a/threedi_model_migration/schematisation.py
+++ b/threedi_model_migration/schematisation.py
@@ -1,3 +1,5 @@
+from .file import File
+from .file import Raster
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -19,6 +21,10 @@ class SchemaRevision:
     last_update: datetime
     commit_msg: str
     commit_user: str
+
+    # files
+    sqlite: File
+    rasters: List[Raster]
 
     def __repr__(self):
         return f"SchemaRevision({self.revision_nr})"

--- a/threedi_model_migration/sql.py
+++ b/threedi_model_migration/sql.py
@@ -1,0 +1,57 @@
+from .file import RasterOptions
+
+import logging
+import sqlite3
+
+
+logger = logging.getLogger(__name__)
+
+# build sql queries
+GLOBAL_SETTINGS_SQL = "FROM v2_global_settings"
+INTERFLOW_SQL = "FROM v2_global_settings LEFT JOIN v2_interflow ON v2_interflow.id = v2_global_settings.interflow_settings_id"
+SIMPLE_INFILTRATION_SQL = "FROM v2_global_settings LEFT JOIN v2_simple_infiltration ON v2_simple_infiltration.id = v2_global_settings.simple_infiltration_settings_id"
+GROUNDWATER_SQL = "FROM v2_global_settings LEFT JOIN v2_groundwater ON v2_groundwater.id = v2_global_settings.groundwater_settings_id"
+ORDER_BY = "ORDER BY v2_global_settings.id"
+RASTER_SQL_MAP = {}
+for option in (
+    RasterOptions.dem_file,
+    RasterOptions.frict_coef_file,
+    RasterOptions.interception_file,
+    RasterOptions.initial_waterlevel_file,
+    RasterOptions.initial_groundwater_level_file,
+):
+    RASTER_SQL_MAP[option] = " ".join([option.name, GLOBAL_SETTINGS_SQL, ORDER_BY])
+for option in (
+    RasterOptions.porosity_file,
+    RasterOptions.hydraulic_conductivity_file,
+):
+    RASTER_SQL_MAP[option] = " ".join([option.name, INTERFLOW_SQL, ORDER_BY])
+for option in (
+    RasterOptions.infiltration_rate_file,
+    RasterOptions.max_infiltration_capacity_file,
+):
+    RASTER_SQL_MAP[option] = " ".join([option.name, SIMPLE_INFILTRATION_SQL, ORDER_BY])
+for option in (
+    RasterOptions.equilibrium_infiltration_rate_file,
+    RasterOptions.groundwater_hydro_connectivity_file,
+    RasterOptions.groundwater_impervious_layer_level_file,
+    RasterOptions.infiltration_decay_period_file,
+    RasterOptions.initial_infiltration_rate_file,
+    RasterOptions.phreatic_storage_capacity_file,
+    RasterOptions.leakage_file,
+):
+    RASTER_SQL_MAP[option] = " ".join([option.name, GROUNDWATER_SQL, ORDER_BY])
+
+SETTINGS_SQL = " ".join(["id, name", GLOBAL_SETTINGS_SQL, ORDER_BY])
+
+
+def select(full_path, query):
+    con = sqlite3.connect(full_path)
+    try:
+        with con:
+            cursor = con.execute("SELECT " + query)
+        records = cursor.fetchall()
+    finally:
+        con.close()
+
+    return records

--- a/threedi_model_migration/tests/conftest.py
+++ b/threedi_model_migration/tests/conftest.py
@@ -70,7 +70,8 @@ def repository(tmp_path_factory):
         con.execute(f"CREATE TABLE {GLOBAL_SETTINGS_SCHEMA}")
         con.execute(f"CREATE TABLE {INTERFLOW_SCHEMA}")
         con.execute(f"CREATE TABLE {SIMPLE_INFILTRATION_SCHEMA}")
-        con.execute(f"CREATE TABLE {GROUNDWATER_SCHEMA}")
+        # This asserts that inspect() passes without a groundwater table:
+        # con.execute(f"CREATE TABLE {GROUNDWATER_SCHEMA}")
         con.execute(
             "INSERT INTO v2_global_settings (id, name, dem_file) VALUES (1, 'default', 'rasters/dem.tif')"
         )

--- a/threedi_model_migration/tests/conftest.py
+++ b/threedi_model_migration/tests/conftest.py
@@ -8,6 +8,50 @@ import sqlite3
 
 DATA_PATH = Path(__file__).parent / "data"
 
+GLOBAL_SETTINGS_SCHEMA = """
+v2_global_settings (
+    id int,
+    name varchar(255),
+    dem_file varchar(255),
+    frict_coef_file varchar(255),
+    interception_file varchar(255),
+    initial_waterlevel_file varchar(255),
+    initial_groundwater_level_file varchar(255),
+    interflow_settings_id int,
+    simple_infiltration_settings_id int,
+    groundwater_settings_id int
+)
+"""
+
+INTERFLOW_SCHEMA = """
+v2_interflow (
+    id int,
+    porosity_file varchar(255),
+    hydraulic_conductivity_file varchar(255)
+)
+"""
+
+SIMPLE_INFILTRATION_SCHEMA = """
+v2_simple_infiltration (
+    id int,
+    infiltration_rate_file varchar(255),
+    max_infiltration_capacity_file varchar(255)
+)
+"""
+
+GROUNDWATER_SCHEMA = """
+v2_groundwater (
+    id int,
+    groundwater_impervious_layer_level_file varchar(255),
+    phreatic_storage_capacity_file varchar(255),
+    equilibrium_infiltration_rate_file varchar(255),
+    initial_infiltration_rate_file varchar(255),
+    infiltration_decay_period_file varchar(255),
+    groundwater_hydro_connectivity_file varchar(255),
+    leakage_file varchar(255)
+)
+"""
+
 
 @pytest.fixture(scope="session")
 def metadata_json_path():
@@ -23,8 +67,13 @@ def repository(tmp_path_factory):
     # write a sqlite
     con = sqlite3.connect(repo_path / "db1.sqlite")
     with con:
-        con.execute("CREATE TABLE v2_global_settings (id int, name varchar(255))")
-        con.execute("INSERT INTO v2_global_settings VALUES (1, 'default')")
+        con.execute(f"CREATE TABLE {GLOBAL_SETTINGS_SCHEMA}")
+        con.execute(f"CREATE TABLE {INTERFLOW_SCHEMA}")
+        con.execute(f"CREATE TABLE {SIMPLE_INFILTRATION_SCHEMA}")
+        con.execute(f"CREATE TABLE {GROUNDWATER_SCHEMA}")
+        con.execute(
+            "INSERT INTO v2_global_settings (id, name, dem_file) VALUES (1, 'default', 'rasters/dem.tif')"
+        )
     con.close()
     hg.add(repo_path, "db1.sqlite")
     hg.commit(repo_path, "db1.sqlite", "My first commit")
@@ -32,9 +81,19 @@ def repository(tmp_path_factory):
     # add another sqlite
     con = sqlite3.connect(repo_path / "db2.sqlite")
     with con:
-        con.execute("CREATE TABLE v2_global_settings (id int, name varchar(255))")
-        con.execute("INSERT INTO v2_global_settings VALUES (1, 'default')")
-        con.execute("INSERT INTO v2_global_settings VALUES (2, 'breach')")
+        con.execute(f"CREATE TABLE {GLOBAL_SETTINGS_SCHEMA}")
+        con.execute(f"CREATE TABLE {INTERFLOW_SCHEMA}")
+        con.execute(f"CREATE TABLE {SIMPLE_INFILTRATION_SCHEMA}")
+        con.execute(f"CREATE TABLE {GROUNDWATER_SCHEMA}")
+        con.execute(
+            "INSERT INTO v2_global_settings (id, name, dem_file) VALUES (1, 'default', 'rasters/dem.tif')"
+        )
+        con.execute(
+            "INSERT INTO v2_global_settings (id, name, dem_file, groundwater_settings_id) VALUES (2, 'groundwater', 'rasters/dem.tif', 1)"
+        )
+        con.execute(
+            "INSERT INTO v2_groundwater (id, groundwater_impervious_layer_level_file) VALUES (1, 'rasters/x.tif')"
+        )
     con.close()
     hg.add(repo_path, "db2.sqlite")
     hg.commit(repo_path, "db2.sqlite", "My second commit")

--- a/threedi_model_migration/tests/test_conversion.py
+++ b/threedi_model_migration/tests/test_conversion.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from pathlib import Path
 from threedi_model_migration.conversion import repository_to_schematisations
+from threedi_model_migration.file import File
 from threedi_model_migration.repository import RepoRevision
 from threedi_model_migration.repository import RepoSettings
 from threedi_model_migration.repository import Repository
@@ -10,6 +11,7 @@ import pytest
 
 
 def gen_repo(*revision_sqlites):
+    files = [File(path=f"db{i}") for i in range(1, 4)]
     revisions = [
         RepoRevision(
             i + 1,
@@ -18,6 +20,7 @@ def gen_repo(*revision_sqlites):
             f"My {i}nd commit",
             "username",
             sqlites=sqlites,
+            changes=files,
         )
         for i, sqlites in enumerate(revision_sqlites)
     ]

--- a/threedi_model_migration/tests/test_conversion.py
+++ b/threedi_model_migration/tests/test_conversion.py
@@ -177,7 +177,7 @@ def gen_repo(*revision_sqlites):
     ],
 )
 def test_repo_to_schema(repository, expected_names, expected_nrs):
-    actual = repository_to_schematisations(repository)
+    actual = repository_to_schematisations(repository)["schematisations"]
 
     # sort by schematisation name
     actual = sorted(actual, key=lambda x: x.concat_name)

--- a/threedi_model_migration/tests/test_conversion.py
+++ b/threedi_model_migration/tests/test_conversion.py
@@ -11,7 +11,7 @@ import pytest
 
 
 def gen_repo(*revision_sqlites):
-    files = [File(path=f"db{i}") for i in range(1, 4)]
+    files = [File(path=f"db{i}", md5=f"abc{i}", size=i * 1024) for i in range(1, 4)]
     revisions = [
         RepoRevision(
             i + 1,
@@ -20,7 +20,7 @@ def gen_repo(*revision_sqlites):
             f"My {i}nd commit",
             "username",
             sqlites=sqlites,
-            changes=files,
+            changes=files if i == 0 else [],
         )
         for i, sqlites in enumerate(revision_sqlites)
     ]

--- a/threedi_model_migration/tests/test_repository.py
+++ b/threedi_model_migration/tests/test_repository.py
@@ -45,12 +45,12 @@ def test_settings(repository_inspected):
     assert settings[0].settings_id == 1
     assert settings[0].settings_name == "default"
     assert len(settings[0].rasters) == 1
-    assert settings[0].rasters[0].raster_type == RasterOptions.dem_raw_file.value
+    assert settings[0].rasters[0].raster_type == RasterOptions.dem_file.value
     assert settings[0].rasters[0].path == Path("rasters/dem.tif")
     assert settings[1].settings_id == 2
     assert settings[1].settings_name == "groundwater"
     assert len(settings[1].rasters) == 2
-    assert settings[1].rasters[0].raster_type == RasterOptions.dem_raw_file.value
+    assert settings[1].rasters[0].raster_type == RasterOptions.dem_file.value
     assert settings[1].rasters[0].path == Path("rasters/dem.tif")
     assert (
         settings[1].rasters[1].raster_type

--- a/threedi_model_migration/tests/test_repository.py
+++ b/threedi_model_migration/tests/test_repository.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+
+
 def test_revisions(repository_inspected):
     revisions = repository_inspected.revisions
     assert len(revisions) == 2
@@ -34,8 +37,12 @@ def test_settings(repository_inspected):
 
     assert settings[0].settings_id == 1
     assert settings[0].settings_name == "default"
+    assert settings[0].dem_file == Path("rasters/dem.tif")
+    assert settings[0].groundwater_impervious_layer_level_file is None
     assert settings[1].settings_id == 2
-    assert settings[1].settings_name == "breach"
+    assert settings[1].settings_name == "groundwater"
+    assert settings[1].dem_file == Path("rasters/dem.tif")
+    assert settings[1].groundwater_impervious_layer_level_file == Path("rasters/x.tif")
 
 
 def test_inspect(repository_inspected):

--- a/threedi_model_migration/tests/test_repository.py
+++ b/threedi_model_migration/tests/test_repository.py
@@ -39,16 +39,16 @@ def test_settings(repository_inspected):
     assert settings[0].settings_id == 1
     assert settings[0].settings_name == "default"
     assert len(settings[0].rasters) == 1
-    assert settings[0].rasters[0].raster_type == RasterOptions.dem_raw_file
+    assert settings[0].rasters[0].raster_type == RasterOptions.dem_raw_file.value
     assert settings[0].rasters[0].path == Path("rasters/dem.tif")
     assert settings[1].settings_id == 2
     assert settings[1].settings_name == "groundwater"
     assert len(settings[1].rasters) == 2
-    assert settings[1].rasters[0].raster_type == RasterOptions.dem_raw_file
+    assert settings[1].rasters[0].raster_type == RasterOptions.dem_raw_file.value
     assert settings[1].rasters[0].path == Path("rasters/dem.tif")
     assert (
         settings[1].rasters[1].raster_type
-        == RasterOptions.groundwater_impervious_layer_level_file
+        == RasterOptions.groundwater_impervious_layer_level_file.value
     )
     assert settings[1].rasters[1].path == Path("rasters/x.tif")
 

--- a/threedi_model_migration/tests/test_repository.py
+++ b/threedi_model_migration/tests/test_repository.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from threedi_model_migration.file import RasterOptions
 
 
 def test_revisions(repository_inspected):
@@ -37,12 +38,19 @@ def test_settings(repository_inspected):
 
     assert settings[0].settings_id == 1
     assert settings[0].settings_name == "default"
-    assert settings[0].dem_file == Path("rasters/dem.tif")
-    assert settings[0].groundwater_impervious_layer_level_file is None
+    assert len(settings[0].rasters) == 1
+    assert settings[0].rasters[0].raster_type == RasterOptions.dem_raw_file
+    assert settings[0].rasters[0].path == Path("rasters/dem.tif")
     assert settings[1].settings_id == 2
     assert settings[1].settings_name == "groundwater"
-    assert settings[1].dem_file == Path("rasters/dem.tif")
-    assert settings[1].groundwater_impervious_layer_level_file == Path("rasters/x.tif")
+    assert len(settings[1].rasters) == 2
+    assert settings[1].rasters[0].raster_type == RasterOptions.dem_raw_file
+    assert settings[1].rasters[0].path == Path("rasters/dem.tif")
+    assert (
+        settings[1].rasters[1].raster_type
+        == RasterOptions.groundwater_impervious_layer_level_file
+    )
+    assert settings[1].rasters[1].path == Path("rasters/x.tif")
 
 
 def test_inspect(repository_inspected):


### PR DESCRIPTION
This adds "rasters" under `RepoSettings` and "changes" under `RepoRevision`. With these two new fields, we can add the files (sqlite + rasters) to the schematisation revision and filter out files that occur more than once.

For the analysis later I added the total file count and an estimate of the schematisation size.