### PR TITLE
Fix revision number setting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ History
 0.6.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix revision number setting.
 
 
 0.6.0 (2021-12-16)

--- a/threedi_model_migration/api_utils.py
+++ b/threedi_model_migration/api_utils.py
@@ -185,7 +185,7 @@ def get_or_create_revision(
     logger.info(f"Creating revision {revision.revision_nr}...")
     obj = OACreateRevision(empty=True)
     if set_revision_nr:
-        obj.revision_nr = revision.revision_nr
+        obj.number = revision.revision_nr
     resp = api.schematisations_revisions_create(schema_id, obj)
     return resp, True
 

--- a/threedi_model_migration/api_utils.py
+++ b/threedi_model_migration/api_utils.py
@@ -183,9 +183,9 @@ def get_or_create_revision(
         return resp.results[0], False
 
     logger.info(f"Creating revision {revision.revision_nr}...")
-    obj = OACreateRevision(empty=True)
-    if set_revision_nr:
-        obj.number = revision.revision_nr
+    obj = OACreateRevision(
+        empty=True, number=revision.revision_nr if set_revision_nr else None
+    )
     resp = api.schematisations_revisions_create(schema_id, obj)
     return resp, True
 


### PR DESCRIPTION
In the OpenAPI model, the revision number is called `number`, not `revision_nr`. You can of course stick any attribute to a python object, so the previous code didn't error, it just silently ignored the revision number.