### PR TITLE
Adapt schematisation name and slug

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ History
 0.6.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Adapt schematisation name to be more similar to the old convention.
 
 
 0.6.1 (2021-12-20)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,10 @@ History
 0.6.2 (unreleased)
 ------------------
 
-- Adapt schematisation name to be more similar to the old convention.
+- Adapt schematisation name and slug to be more similar to the old convention and to
+  fix slug uniqueness issues.
+
+- Changed Schematisation.sqlite_name to Schematisation.sqlite_path.
 
 
 0.6.1 (2021-12-20)

--- a/threedi_model_migration/api_utils.py
+++ b/threedi_model_migration/api_utils.py
@@ -77,7 +77,7 @@ def get_or_create_schematisation(
         tags=["models.lizard.net"],
         meta={
             "repository": schematisation.repo_slug,
-            "sqlite_name": schematisation.sqlite_name,
+            "sqlite_path": str(schematisation.sqlite_path),
             "settings_id": schematisation.settings_id,
             "settings_name": schematisation.settings_name,
             **schematisation.metadata.meta,

--- a/threedi_model_migration/schematisation.py
+++ b/threedi_model_migration/schematisation.py
@@ -62,14 +62,16 @@ class Schematisation:
         - v2_bergermeer - bergermeer_Bergermeer (1, directory: model)
         """
         # The 'mdu_name' is formatted exactly like inpy does for threedimodels
-        mdu_name = f"{self.sqlite_path.stem}_{self.settings_name}"
+        settings_name = self.settings_name if self.settings_name else self.settings_id
+        mdu_name = f"{self.sqlite_path.stem}_{settings_name}"
         # To make the name unique, include the containing dir and settings id as
         # extra info between parentheses
         if str(self.sqlite_path.parent) != ".":
             extra_info = f", directory: {self.sqlite_path.parent}"
         else:
             extra_info = ""
-        return (f"{self.repo_slug} - {mdu_name} ({self.settings_id}{extra_info})")[:256]
+        name = f"{self.repo_slug} - {mdu_name} ({self.settings_id}{extra_info})"
+        return name[:256]
 
     @property
     def slug(self):

--- a/threedi_model_migration/schematisation.py
+++ b/threedi_model_migration/schematisation.py
@@ -36,7 +36,7 @@ class SchemaRevision:
 @dataclass
 class Schematisation:
     repo_slug: str
-    sqlite_name: str  # the newest of its revisions
+    sqlite_path: Path  # the newest of its revisions
     settings_id: int
     settings_name: str  # the newest of its revisions
     metadata: Optional[SchemaMeta] = None
@@ -44,10 +44,41 @@ class Schematisation:
 
     @property
     def name(self):
-        return f"{self.repo_slug} - {self.sqlite_name}_{self.settings_name}"[:256]
+        """Construct the name of the schematisation.
+
+        Due to legacy considerations, the start of the name is:
+
+          {repo_slug} - {sqlite filename}_{global settings name}
+
+        However this leads to non-unique slugs in many cases. Because of that we add
+        some extra info between parentheses:
+
+          {settings_id}[, directory: {sqlite directory}]
+
+        Resulting names are for example:
+
+        - v2_bergermeer - v2_bergermeer_simple_infil_no_grndwtr (1)
+        - schermerboezem - schermer_1d2d_default (1)
+        - v2_bergermeer - bergermeer_Bergermeer (1, directory: model)
+        """
+        # The 'mdu_name' is formatted exactly like inpy does for threedimodels
+        mdu_name = f"{self.sqlite_path.stem}_{self.settings_name}"
+        # To make the name unique, include the containing dir and settings id as
+        # extra info between parentheses
+        if str(self.sqlite_path.parent) != ".":
+            extra_info = f", directory: {self.sqlite_path.parent}"
+        else:
+            extra_info = ""
+        return (f"{self.repo_slug} - {mdu_name} ({self.settings_id}{extra_info})")[:256]
 
     @property
     def slug(self):
+        """Slugified version of name, examples:
+
+        - v2_bergermeer-v2_bergermeer_simple_infil_no_grndwtr-1
+        - schermerboezem-schermer_1d2d_default-1
+        - v2_bergermeer-bergermeer_bergermeer-1-directory-model
+        """
         return slugify(self.name)
 
     def get_files(self) -> Set[File]:

--- a/threedi_model_migration/schematisation.py
+++ b/threedi_model_migration/schematisation.py
@@ -44,10 +44,7 @@ class Schematisation:
 
     @property
     def name(self):
-        return (
-            f"{self.repo_slug} - {self.sqlite_name} - "
-            f"{self.settings_id} {self.settings_name}"
-        )[:256]
+        return f"{self.repo_slug} - {self.sqlite_name}_{self.settings_name}"[:256]
 
     @property
     def slug(self):

--- a/threedi_model_migration/sql.py
+++ b/threedi_model_migration/sql.py
@@ -63,7 +63,7 @@ def select(full_path, query):
 
 def filter_global_settings(full_path, settings_id):
     """Remove global settings, keeping only `settings_id`"""
-    settings_id = int(settings_id)   # prevents SQL injection
+    settings_id = int(settings_id)  # prevents SQL injection
     con = sqlite3.connect(full_path)
     try:
         with con:

--- a/threedi_model_migration/tests/test_conversion.py
+++ b/threedi_model_migration/tests/test_conversion.py
@@ -37,7 +37,7 @@ def gen_repo(*revision_sqlites, changes=None):
         # One revision, one sqlite, one settings entry
         (
             gen_repo([Sql(Path("db1"), settings=[Sett(1, "a")])]),
-            ["testrepo - db1 - 1 a"],
+            ["testrepo - db1_a (1)"],
             [[0]],
         ),
         # Two revisions with the same sqlite and settings
@@ -46,7 +46,7 @@ def gen_repo(*revision_sqlites, changes=None):
                 [Sql(Path("db1"), settings=[Sett(1, "a")])],
                 [Sql(Path("db1"), settings=[Sett(1, "a")])],
             ),
-            ["testrepo - db1 - 1 a"],
+            ["testrepo - db1_a (1)"],
             [[1, 0]],
         ),
         # One revision with two sqlites with the same settings
@@ -57,28 +57,18 @@ def gen_repo(*revision_sqlites, changes=None):
                     Sql(Path("db2"), settings=[Sett(1, "a")]),
                 ]
             ),
-            ["testrepo - db1 - 1 a", "testrepo - db2 - 1 a"],
+            ["testrepo - db1_a (1)", "testrepo - db2_a (1)"],
             [[0], [0]],
         ),
-        # One revision with one sqlites with two settings
+        # One revision with one sqlite with two settings
         (
             gen_repo(
                 [
-                    Sql(Path("db1"), settings=[Sett(1, "a")]),
-                    Sql(Path("db1"), settings=[Sett(2, "b")]),
+                    Sql(Path("db1"), settings=[Sett(1, "a"), Sett(2, "b")]),
                 ]
             ),
-            ["testrepo - db1 - 1 a", "testrepo - db1 - 2 b"],
+            ["testrepo - db1_a (1)", "testrepo - db1_b (2)"],
             [[0], [0]],
-        ),
-        # Two revisions with one sqlites with different settings ("settings renumbered")
-        (
-            gen_repo(
-                [Sql(Path("db1"), settings=[Sett(2, "b")])],
-                [Sql(Path("db1"), settings=[Sett(1, "a")])],
-            ),
-            ["testrepo - db1 - 1 a", "testrepo - db1 - 2 b"],
-            [[0], [1]],
         ),
         # Two revisions with the same sqlite and settings, one sqlite added
         (
@@ -89,19 +79,19 @@ def gen_repo(*revision_sqlites, changes=None):
                 ],
                 [Sql(Path("db1"), settings=[Sett(1, "a")])],
             ),
-            ["testrepo - db1 - 1 a", "testrepo - db2 - 1 a"],
+            ["testrepo - db1_a (1)", "testrepo - db2_a (1)"],
             [[1, 0], [1]],
         ),
         # Two revisions with the same sqlite and settings, one settings entry added
         (
             gen_repo(
                 [
-                    Sql(Path("db1"), settings=[Sett(1, "a")]),
-                    Sql(Path("db1"), settings=[Sett(2, "b")]),
+                    Sql(Path("db1"), settings=[Sett(1, "a"), Sett(2, "b")]),
+                    Sql(Path("db1"), settings=[]),
                 ],
                 [Sql(Path("db1"), settings=[Sett(1, "a")])],
             ),
-            ["testrepo - db1 - 1 a", "testrepo - db1 - 2 b"],
+            ["testrepo - db1_a (1)", "testrepo - db1_b (2)"],
             [[1, 0], [1]],
         ),
         # Setting is renamed: it is tracked (and the last revision will set the name)
@@ -110,23 +100,21 @@ def gen_repo(*revision_sqlites, changes=None):
                 [Sql(Path("db1"), settings=[Sett(1, "b")])],
                 [Sql(Path("db1"), settings=[Sett(1, "a")])],
             ),
-            ["testrepo - db1 - 1 b"],
+            ["testrepo - db1_b (1)"],
             [[1, 0]],
         ),
         # Settings entry skips a revision
         (
             gen_repo(
                 [
-                    Sql(Path("db1"), settings=[Sett(1, "a")]),
-                    Sql(Path("db1"), settings=[Sett(2, "c")]),
+                    Sql(Path("db1"), settings=[Sett(1, "a"), Sett(2, "c")]),
                 ],
                 [Sql(Path("db1"), settings=[Sett(1, "a")])],
                 [
-                    Sql(Path("db1"), settings=[Sett(1, "a")]),
-                    Sql(Path("db1"), settings=[Sett(2, "b")]),
+                    Sql(Path("db1"), settings=[Sett(1, "a"), Sett(2, "b")]),
                 ],
             ),
-            ["testrepo - db1 - 1 a", "testrepo - db1 - 2 c"],
+            ["testrepo - db1_a (1)", "testrepo - db1_c (2)"],
             [[2, 1, 0], [2, 0]],
         ),
         # Renaming an sqlite is not allowed
@@ -135,7 +123,7 @@ def gen_repo(*revision_sqlites, changes=None):
                 [Sql(Path("db2"), settings=[Sett(1, "a")])],
                 [Sql(Path("db1"), settings=[Sett(1, "a")])],
             ),
-            ["testrepo - db1 - 1 a", "testrepo - db2 - 1 a"],
+            ["testrepo - db1_a (1)", "testrepo - db2_a (1)"],
             [[0], [1]],
         ),
         # File is missing in changet of 2nd revision
@@ -145,7 +133,7 @@ def gen_repo(*revision_sqlites, changes=None):
                 [Sql(Path("db1"), settings=[Sett(1, "a")])],
                 changes=[[], [Path("db1")]],
             ),
-            ["testrepo - db1 - 1 a"],
+            ["testrepo - db1_a (1)"],
             [[0]],
         ),
         # Sqlite is missing in changet of 2nd revision but a raster was changed
@@ -169,7 +157,7 @@ def gen_repo(*revision_sqlites, changes=None):
                 ],
                 changes=[[Path("r.tiff")], [Path("db1"), Path("r.tiff")]],
             ),
-            ["testrepo - db1 - 1 a"],
+            ["testrepo - db1_a (1)"],
             [[1, 0]],
         ),
         # Sqlite is missing in changet of 2nd revision and no raster was changed
@@ -193,8 +181,17 @@ def gen_repo(*revision_sqlites, changes=None):
                 ],
                 changes=[[], [Path("db1"), Path("r.tiff")]],
             ),
-            ["testrepo - db1 - 1 a"],
+            ["testrepo - db1_a (1)"],
             [[0]],
+        ),
+        # The case and interpunction in filenames is ignored
+        (
+            gen_repo(
+                [Sql(Path("db1a"), settings=[Sett(1, "a")])],
+                [Sql(Path("DB1;a"), settings=[Sett(1, "a")])],
+            ),
+            ["testrepo - db1a_a (1)"],
+            [[1, 0]],
         ),
     ],
 )


### PR DESCRIPTION
It appeared to be impossible to add some extra metadata on revision level, so instead I changed the slug of the schematisations to match the legacy threedimodel names.

You can use the slug in the filter `threedimodels/?slug__startswith=...` to find matching old AND new threedimodels