### PR TITLE
Fix errors with non-UTF-8 name in schematisation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ History
 1.0.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix issues with non-UTF-8 characters in metadata.
 
 
 1.0.3 (2022-02-14)

--- a/threedi_model_migration/api_utils.py
+++ b/threedi_model_migration/api_utils.py
@@ -2,6 +2,7 @@ from .file import Raster
 from .file import RasterOptions
 from .schematisation import SchemaRevision
 from .schematisation import Schematisation
+from .text_utils import make_utf8
 from .zip_utils import deterministic_zip
 from enum import Enum
 from pathlib import Path
@@ -75,14 +76,14 @@ def get_or_create_schematisation(
     logger.info(f"Creating schematisation '{schematisation.slug}'...")
     obj = OASchematisation(
         owner=schematisation.metadata.owner,
-        name=schematisation.name,
+        name=make_utf8(schematisation.name),
         slug=schematisation.slug,
         tags=["models.lizard.net"],
         meta={
             "repository": schematisation.repo_slug,
-            "sqlite_path": str(schematisation.sqlite_path),
+            "sqlite_path": make_utf8(str(schematisation.sqlite_path)),
             "settings_id": schematisation.settings_id,
-            "settings_name": schematisation.settings_name,
+            "settings_name": make_utf8(schematisation.settings_name),
             **schematisation.metadata.meta,
         },
         created_by=schematisation.metadata.created_by,
@@ -203,7 +204,7 @@ def upload_sqlite(api: V3BetaApi, rev_id: int, schema_id: int, sqlite_path: Path
         md5 = hashlib.md5(f.read())
         f.seek(0)
         obj = OASqlite(
-            filename=sqlite_path.stem + ".zip",
+            filename=make_utf8(sqlite_path.stem) + ".zip",
             md5sum=md5.hexdigest(),
         )
         upload = api.schematisations_revisions_sqlite_upload(rev_id, schema_id, obj)
@@ -221,7 +222,7 @@ def upload_raster(
 ):
     raster_type = RasterOptions(raster.raster_type).value
     logger.info(f"Creating '{raster_type}' raster...")
-    obj = OARaster(name=raster.path.name[:60], md5sum=raster.md5, type=raster_type)
+    obj = OARaster(name=make_utf8(raster.path.name)[:60], md5sum=raster.md5, type=raster_type)
     resp = api.schematisations_revisions_rasters_create(rev_id, schema_id, obj)
     if resp.file and resp.file.state == "uploaded":
         logger.info(f"Raster '{str(raster.path)}' already existed, skipping upload.")
@@ -229,7 +230,7 @@ def upload_raster(
 
     logger.info(f"Uploading '{str(raster.path)}'...")
     obj = OAUpload(
-        filename=raster.path.name,
+        filename=make_utf8(raster.path.name),
     )
     upload = api.schematisations_revisions_rasters_upload(
         resp.id, rev_id, schema_id, obj
@@ -298,7 +299,7 @@ def commit_revision(
     # In the API, the 'user' is just a string and 'commit_user' is an FK to user
     user = revision.commit_user
     obj = OACommit(
-        commit_message=revision.commit_msg if revision.commit_msg != "" else None,
+        commit_message=make_utf8(revision.commit_msg) if revision.commit_msg != "" else None,
         commit_date=revision.last_update,
         user=user,
     )

--- a/threedi_model_migration/api_utils.py
+++ b/threedi_model_migration/api_utils.py
@@ -222,7 +222,9 @@ def upload_raster(
 ):
     raster_type = RasterOptions(raster.raster_type).value
     logger.info(f"Creating '{raster_type}' raster...")
-    obj = OARaster(name=make_utf8(raster.path.name)[:60], md5sum=raster.md5, type=raster_type)
+    obj = OARaster(
+        name=make_utf8(raster.path.name)[:60], md5sum=raster.md5, type=raster_type
+    )
     resp = api.schematisations_revisions_rasters_create(rev_id, schema_id, obj)
     if resp.file and resp.file.state == "uploaded":
         logger.info(f"Raster '{str(raster.path)}' already existed, skipping upload.")
@@ -299,7 +301,9 @@ def commit_revision(
     # In the API, the 'user' is just a string and 'commit_user' is an FK to user
     user = revision.commit_user
     obj = OACommit(
-        commit_message=make_utf8(revision.commit_msg) if revision.commit_msg != "" else None,
+        commit_message=make_utf8(revision.commit_msg)
+        if revision.commit_msg != ""
+        else None,
         commit_date=revision.last_update,
         user=user,
     )

--- a/threedi_model_migration/text_utils.py
+++ b/threedi_model_migration/text_utils.py
@@ -21,3 +21,8 @@ def slugify(value, allow_unicode=False):
         )
     value = re.sub(r"[^\w\s-]", "", value).strip().lower()
     return re.sub(r"[-\s]+", "-", value)
+
+
+def make_utf8(value):
+    """Remove non-utf-8 characters with a question mark"""
+    return value.encode("utf-8", "replace").decode("utf-8")


### PR DESCRIPTION
A repo with this name: `yanshui_2mc\udca1\udcc4v69.sqlite` gave the following error:`HTTP response body: {"name":["Surrogate characters are not allowed: U+DCA1."]}`

This code replaces the so-called surrogate characters starting with `\u` with a question mark.

